### PR TITLE
Reduce the specificity of the WindowProxy changes.

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -24,13 +24,11 @@ DOMInterfaces = {
 'URL': {
     'weakReferenceable': True,
 },
-'HTMLIFrameElement': {
-    'importTypes': ['dom::types::Window', 'dom::browsingcontext::BrowsingContext']
-},
+
 'WindowProxy' : {
-    'correspondToBrowsingContext': True,
-    'nativeBinding': 'dom::browsingcontext::BrowsingContext',
-    'register': False
+    'nativeType': 'BrowsingContext',
+    'path': 'dom::browsingcontext::BrowsingContext',
+    'register': False,
 }
 
 }

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -173,10 +173,7 @@ class Descriptor(DescriptorProvider):
 
         # Read the desc, and fill in the relevant defaults.
         ifaceName = self.interface.identifier.name
-        self.register = desc.get('register', True)
-        self.outerObjectHook = desc.get('outerObjectHook', 'None')
-        self.correspondToBrowsingContext = desc.get('correspondToBrowsingContext', False)
-        self.importTypes = desc.get('importTypes', [])
+        typeName = desc.get('nativeType', ifaceName)
 
         # Callback types do not use JS smart pointers, so we should not use the
         # built-in rooting mechanisms for them.
@@ -186,18 +183,16 @@ class Descriptor(DescriptorProvider):
             self.returnType = "Rc<%s>" % ty
             self.argumentType = "???"
             self.nativeType = ty
-        elif self.correspondToBrowsingContext:
-            self.needsRooting = True
-            self.returnType = "Root<BrowsingContext>"
-            self.argumentType = "&BrowsingContext"
-            self.nativeType = "*const BrowsingContext"
         else:
             self.needsRooting = True
-            self.returnType = "Root<%s>" % ifaceName
-            self.argumentType = "&%s" % ifaceName
-            self.nativeType = "*const %s" % ifaceName
+            self.returnType = "Root<%s>" % typeName
+            self.argumentType = "&%s" % typeName
+            self.nativeType = "*const %s" % typeName
 
-        self.concreteType = ifaceName
+        self.concreteType = typeName
+        self.register = desc.get('register', True)
+        self.path = desc.get('path', 'dom::types::%s' % typeName)
+        self.outerObjectHook = desc.get('outerObjectHook', 'None')
         self.proxy = False
         self.weakReferenceable = desc.get('weakReferenceable', False)
 

--- a/components/script/dom/bindings/codegen/parser/WebIDL.py
+++ b/components/script/dom/bindings/codegen/parser/WebIDL.py
@@ -798,7 +798,7 @@ class IDLInterface(IDLObjectWithScope, IDLExposureMixins):
             # Interfaces with [Global] or [PrimaryGlobal] must not
             # have anything inherit from them
             if (self.parent.getExtendedAttribute("Global") or
-                self.parent.getExtendedAttribute("PrimaryGlobal") and not self.getExtendedAttribute("NoInterfaceObject")):
+                self.parent.getExtendedAttribute("PrimaryGlobal")):
                 # Note: This is not a self.parent.isOnGlobalProtoChain() check
                 # because ancestors of a [Global] interface can have other
                 # descendants.

--- a/components/script/dom/webidls/BrowserElement.webidl
+++ b/components/script/dom/webidls/BrowserElement.webidl
@@ -159,16 +159,16 @@ interface BrowserElementPrivileged {
   //                    unsigned long count,
   //                    unsigned long modifiers);
 
-  [Func="Window::global_is_mozbrowser", Throws]
+  [Func="::dom::window::Window::global_is_mozbrowser", Throws]
   void goBack();
 
-  [Func="Window::global_is_mozbrowser", Throws]
+  [Func="::dom::window::Window::global_is_mozbrowser", Throws]
   void goForward();
 
-  [Func="Window::global_is_mozbrowser", Throws]
+  [Func="::dom::window::Window::global_is_mozbrowser", Throws]
   void reload(optional boolean hardReload = false);
 
-  [Func="Window::global_is_mozbrowser", Throws]
+  [Func="::dom::window::Window::global_is_mozbrowser", Throws]
   void stop();
 
   //[Throws,

--- a/components/script/dom/webidls/HTMLIFrameElement.webidl
+++ b/components/script/dom/webidls/HTMLIFrameElement.webidl
@@ -31,7 +31,7 @@ partial interface HTMLIFrameElement {
 };
 
 partial interface HTMLIFrameElement {
-    [Func="Window::global_is_mozbrowser"]
+    [Func="::dom::window::Window::global_is_mozbrowser"]
     attribute boolean mozbrowser;
 };
 

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -61,7 +61,7 @@ Window implements GlobalEventHandlers;
 Window implements WindowEventHandlers;
 
 [NoInterfaceObject]
-interface WindowProxy : Window {};
+interface WindowProxy {};
 
 // https://html.spec.whatwg.org/multipage/#timers
 [NoInterfaceObject/*, Exposed=Window,Worker*/]


### PR DESCRIPTION
These changes reduce the need for special-casing the `correspondToBrowsingContext` descriptor. Instead, we can exclude it from lists of descriptors that get processed, and allow the configuration file to specify the path to the type that should be imported.
